### PR TITLE
add mavenCentral as priority for repos than jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,10 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            mavenCentral()
+            // JCenter is going read-only repository indefinitely
+            // Gradle is discouraging jcenter to avoid to avoid build issues - pipeline
+            // ref: https://blog.gradle.org/jcenter-shutdown
             jcenter()
         }
 
@@ -38,8 +42,8 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
### Description

JCenter has been offline often and it is causing pipeline issues when trying to download the poms/jars. 
Since JCenter also serves as a mirror for Maven Central, and any dependencies available on Maven Central are also available on JCenter, it is better to rely on Maven Central; even the Gradle team is discouraging the use of JCenter since it became read-only. [Check more info here](https://blog.gradle.org/jcenter-shutdown)

### Changes

- Add maven central
- Add `mavenCentral` as a priority than `jcenter`